### PR TITLE
feat: add auto-approve workflow for pull requests

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,19 @@
+# .github/workflows/auto-approve.yml
+name: Auto-Approve PRs
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+
+permissions:
+  pull-requests: write  # 必须赋予写入权限
+  contents: read
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' # 排除 dependabot 创建的 PR，如果需要自动批准 dependabot 的 PR，请移除此行
+    steps:
+      - name: 自动批准 PR
+        uses: hmarr/auto-approve-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}  # 正确的参数名是 token 而不是 github-token


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically approve pull requests under certain conditions. The workflow is designed to streamline the review process for eligible PRs while excluding those created by Dependabot.

### New GitHub Actions Workflow:
* [`.github/workflows/auto-approve.yml`](diffhunk://#diff-283c890e639e6172004c41edb7d2cce76c882feb45e9135b4dce5dc1e82f0c83R1-R19): Added a new workflow named "Auto-Approve PRs" that triggers on `pull_request` events (e.g., opened, reopened, synchronized). It uses the `hmarr/auto-approve-action` to automatically approve PRs, excluding those created by Dependabot.