### PR TITLE
hotfix: remove unused Timeout and Error middleware from ServiceContext

### DIFF
--- a/internal/svc/serviceContext.go
+++ b/internal/svc/serviceContext.go
@@ -29,9 +29,7 @@ type ServiceContext struct {
 	ShortCodeFilter       filter.Filter
 	SensitiveFilter       sensitive.Filter
 
-	Timeout rest.Middleware
-	Limit   rest.Middleware
-	Error   rest.Middleware
+	Limit rest.Middleware
 }
 
 func NewServiceContext(c config.Config) *ServiceContext {


### PR DESCRIPTION
This pull request refactors the `ServiceContext` struct in `internal/svc/serviceContext.go` by removing unused middleware fields. These changes aim to clean up the code and improve maintainability.

Codebase cleanup:

* [`internal/svc/serviceContext.go`](diffhunk://#diff-94a6a714a97ea9c4a55ba7dbadefefea87d68e880b5f20550c2c1f8fba7efbb1L32-L34): Removed the `Timeout` and `Error` middleware fields from the `ServiceContext` struct, as they are no longer used.